### PR TITLE
Made build-maven.xml cross os; updated README

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,9 +47,8 @@ $ ant
 
 #### Windows
 
-1. (Ant bug) Open `build-maven.xml` and replace any occurrency of `executable="mvn"` with `executable="mvn.bat"`
-2. Build (see next section)
-3. Copy `target/edo-x.y.z.jar` into a folder of your choice
+1. Build (see next section)
+2. Copy `target/edo-x.y.z.jar` into a folder of your choice
 
 ### Build only
 

--- a/build-maven.xml
+++ b/build-maven.xml
@@ -5,8 +5,13 @@
          xmlns:if="ant:if"
          xmlns:unless="ant:unless">
 
+  <condition property="mvnexec" value="mvn.bat">
+    <os family="windows" />
+  </condition>
+  <property name="mvnexec" value="mvn"/>
+
 	<target name="build" description="Build it ">
-	    <exec dir="." executable="mvn.bat">
+	    <exec dir="." executable="${mvnexec}">
 			<arg line="clean package shade:shade -DskipTests" />
 		</exec>
 	</target>


### PR DESCRIPTION
Hi,
the README writes:
Open `build-maven.xml` and replace any occurrency of `executable="mvn"` with `executable="mvn.bat"`

But it is the contrary, because currently the file contains "mvn.bat", so unix users need to perform the rename.

It think that adding a conditional property it could be done automatically. Tested on Ubuntu. Need to be tested by a Windows user.